### PR TITLE
chore: config absolute paths for local imports

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,10 +1,6 @@
 import { format, parseISO } from "date-fns";
 
-import {
-  findBySlug,
-  generateStaticParams,
-  getLocalArticles,
-} from "../../../helpers";
+import { findBySlug, generateStaticParams, getLocalArticles } from "@/helpers";
 
 export { generateStaticParams };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import { ArticleCard } from "../template/ArticleCard";
-import { sortByDate, getLocalArticles } from "../helpers";
+import { ArticleCard } from "@/template/ArticleCard";
+import { sortByDate, getLocalArticles } from "@/helpers";
 
 export default function Home() {
   const articles = sortByDate({ articles: getLocalArticles() });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "baseUrl": ".",
     "paths": {
-      "contentlayer/generated": ["./.contentlayer/generated"]
+      "contentlayer/generated": ["./.contentlayer/generated"],
+      "@/*": ["./src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
This PR configures absolute paths to match `@/` to `.src/`. 

Now all local imports can be done using an absolute path that starts with `@`